### PR TITLE
Compiling Python package with -march=x86-64 and FAST_KER=ON

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -18,10 +18,12 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     
-    # If I compile with gfortran-8 or 9, I guet numerical problems in other machines, not sure why
     - name: install gfortran-7
       run: |
         yum install -y devtoolset-7-toolchain
+        echo "FFLAGS += -march=x86-64" >> make.inc
+        echo "CFLAGS += -march=x86-64" >> make.inc
+        echo "CXXFLAGS += -march=x86-64" >> make.inc
 
     - name: Compile python bindings
       run: |
@@ -61,9 +63,12 @@ jobs:
         echo "FC=gfortran-8" >> make.inc
         echo "CC=gcc-8" >> make.inc
         echo "CXX=g++-8" >> make.inc
-        # link statically to gcc, gfortran and libquadmath
+        echo "FFLAGS += -march=x86-64" >> make.inc
+        echo "CFLAGS += -march=x86-64" >> make.inc
+        echo "CXXFLAGS += -march=x86-64" >> make.inc
+        # link statically to libgcc, libgfortran and libquadmath
         # otherwise binaries are incompatible with older systems
-        echo "LIBS += -static-libgfortran -static-libgcc" >> make.inc
+        echo "LIBS += -static-libgfortran -static-libgcc -static-libstdc++" >> make.inc
         # hack to make libquadmath link statically
         sudo rm /usr/local/opt/gcc@8/lib/gcc/8/libquadmath.*dylib
 

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -18,17 +18,14 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     
-    # If I compile with gfortran-9, I guet numerical problems in other machines, not sure why
-    - name: install gfortran-8
+    # If I compile with gfortran-8 or 9, I guet numerical problems in other machines, not sure why
+    - name: install gfortran-7
       run: |
-        yum install -y devtoolset-8-toolchain
-        echo "FC=/opt/rh/devtoolset-8/root/bin/gfortran" >> make.inc
-        echo "CC=/opt/rh/devtoolset-8/root/bin/gcc" >> make.inc
-        echo "CXX=/opt/rh/devtoolset-8/root/bin/g++" >> make.inc
+        yum install -y devtoolset-7-toolchain
 
     - name: Compile python bindings
       run: |
-        export PATH=/opt/rh/devtoolset-8/root/bin:$PATH
+        scl enable devtoolset-7 bash
         .github/workflows/python_build_posix.sh /opt/python/cp35-cp35m/bin/python
         .github/workflows/python_build_posix.sh /opt/python/cp36-cp36m/bin/python
         .github/workflows/python_build_posix.sh /opt/python/cp37-cp37m/bin/python

--- a/.github/workflows/python_build_posix.sh
+++ b/.github/workflows/python_build_posix.sh
@@ -3,4 +3,4 @@
 PYTHON=$1
 echo "PYTHON=$PYTHON" >> make.inc 
 $PYTHON -m pip install --upgrade setuptools wheel numpy pip
-make python-dist
+make python-dist FAST_KER=ON

--- a/.github/workflows/python_build_win.ps1
+++ b/.github/workflows/python_build_win.ps1
@@ -5,7 +5,9 @@ Set-Variable -Name MSYSTEM -Value MINGW64
 # Setup the make.inc file
 Copy-Item -Path make.inc.windows.mingw -Destination make.inc
 Add-Content -Path make.inc -Value "PYTHON=""$PYTHON"""
-Add-Content -Path make.inc -Value "FFLAGS+= -fallow-argument-mismatch"
+Add-Content -Path make.inc -Value "FFLAGS+= -fallow-argument-mismatch -march=x86-64"
+Add-Content -Path make.inc -Value "CFLAGS+= -march=x86-64"
+Add-Content -Path make.inc -Value "CXXFLAGS+= -march=x86-64"
 
 # Setup the distutils.cfg file
 Set-Variable distutils_cfg -Value ([IO.Path]::Combine((Split-Path -Path $PYTHON), "Lib", 'distutils', 'distutils.cfg'))

--- a/.github/workflows/python_test_posix.sh
+++ b/.github/workflows/python_test_posix.sh
@@ -2,5 +2,5 @@
 # This is an auxiliary script to test wheels
 PYTHON=$1
 $PYTHON -m pip install pytest
-$PYTHON -m pip install fmm3dpy -f wheelhouse/
+$PYTHON -m pip install fmm3dpy -f wheelhouse/ --no-index --no-cache
 $PYTHON -m pytest -s python/test

--- a/python/setup.py
+++ b/python/setup.py
@@ -69,7 +69,7 @@ ext_lap = Extension(
 setup(
     name=pkg_name,
     python_requires='>=3.0.0',
-    version="0.0.3",
+    version="0.0.4",
     author="Zydrunas Gimbutas, Leslie Greengard, Libin Lu, Jeremy Magland, Dhairya Malhotra, Michael O'Neil, Manas Rachh, and Vladimir Rokhlin",
     author_email="mrachh@flatironinstitute.org",
     description="This pacakge contains basic routines for Laplace and Helmholtz fast multipole methods in three dimensions",

--- a/python/setup.py
+++ b/python/setup.py
@@ -69,7 +69,7 @@ ext_lap = Extension(
 setup(
     name=pkg_name,
     python_requires='>=3.0.0',
-    version="0.0.4",
+    version="0.0.5",
     author="Zydrunas Gimbutas, Leslie Greengard, Libin Lu, Jeremy Magland, Dhairya Malhotra, Michael O'Neil, Manas Rachh, and Vladimir Rokhlin",
     author_email="mrachh@flatironinstitute.org",
     description="This pacakge contains basic routines for Laplace and Helmholtz fast multipole methods in three dimensions",


### PR DESCRIPTION
Hello,

I did a few more changes to the CI

* Compiling with -march=x86-64, as the default -march=native can [create binaries which are incompatible with other machines](https://gcc.gnu.org/onlinedocs/gcc/x86-Options.html). I've experienced this problem installing the library in an old Linux computer and this change seems to solve it.
* Compile with FAST_KER=ON on Linux and MacOS.