### PR TITLE
add python 3.12 and 3.13 support in python.yml

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -26,6 +26,8 @@ jobs:
         .github/workflows/python_build_posix.sh /opt/python/cp39-cp39/bin/python
         .github/workflows/python_build_posix.sh /opt/python/cp310-cp310/bin/python
         .github/workflows/python_build_posix.sh /opt/python/cp311-cp311/bin/python
+        .github/workflows/python_build_posix.sh /opt/python/cp312-cp312/bin/python
+        .github/workflows/python_build_posix.sh /opt/python/cp313-cp313/bin/python
         ls python/dist/*.whl | xargs -n1 auditwheel repair
 
     - name: Test python bindings
@@ -36,6 +38,8 @@ jobs:
         .github/workflows/python_test_posix.sh /opt/python/cp39-cp39/bin/python
         .github/workflows/python_test_posix.sh /opt/python/cp310-cp310/bin/python
         .github/workflows/python_test_posix.sh /opt/python/cp311-cp311/bin/python
+        .github/workflows/python_test_posix.sh /opt/python/cp312-cp312/bin/python
+        .github/workflows/python_test_posix.sh /opt/python/cp313-cp313/bin/python
 
     - name: Upload wheels
       uses: actions/upload-artifact@v3
@@ -105,6 +109,16 @@ jobs:
           --output python_installer.pkg
         sudo installer -pkg python_installer.pkg -target /
 
+        curl \
+           https://www.python.org/ftp/python/3.12.0/python-3.12.0-macos11.pkg \
+           --output python_installer.pkg
+         sudo installer -pkg python_installer.pkg -target /
+ 
+         curl \
+           https://www.python.org/ftp/python/3.13.0/python-3.13.0-macos11.pkg \
+           --output python_installer.pkg
+         sudo installer -pkg python_installer.pkg -target /
+
     - name: Compile python bindings
       run: |
         .github/workflows/python_build_posix.sh /Library/Frameworks/Python.framework/Versions/3.6/bin/python3
@@ -113,6 +127,8 @@ jobs:
         .github/workflows/python_build_posix.sh /Library/Frameworks/Python.framework/Versions/3.9/bin/python3
         .github/workflows/python_build_posix.sh /Library/Frameworks/Python.framework/Versions/3.10/bin/python3
         .github/workflows/python_build_posix.sh /Library/Frameworks/Python.framework/Versions/3.11/bin/python3
+        .github/workflows/python_build_posix.sh /Library/Frameworks/Python.framework/Versions/3.12/bin/python3
+        .github/workflows/python_build_posix.sh /Library/Frameworks/Python.framework/Versions/3.13/bin/python3
         PYTHON_BIN=/Library/Frameworks/Python.framework/Versions/3.7/bin/
         $PYTHON_BIN/python3 -m pip install delocate==0.10.7
         ls python/dist/*.whl | xargs -n1 $PYTHON_BIN/delocate-wheel -w wheelhouse/
@@ -125,7 +141,8 @@ jobs:
         .github/workflows/python_test_posix.sh /Library/Frameworks/Python.framework/Versions/3.9/bin/python3
         .github/workflows/python_test_posix.sh /Library/Frameworks/Python.framework/Versions/3.10/bin/python3
         .github/workflows/python_test_posix.sh /Library/Frameworks/Python.framework/Versions/3.11/bin/python3
-
+        .github/workflows/python_test_posix.sh /Library/Frameworks/Python.framework/Versions/3.12/bin/python3
+        .github/workflows/python_test_posix.sh /Library/Frameworks/Python.framework/Versions/3.13/bin/python3
     - name: Upload wheels
       uses: actions/upload-artifact@v3
       with:
@@ -190,6 +207,24 @@ jobs:
       uses: actions/setup-python@v3
       with:
         python-version: '3.11'
+        architecture: 'x64'
+    - run: |
+        .\.github\workflows\python_build_win.ps1
+        .\.github\workflows\python_test_win.ps1
+
+    - name: Build and Test Python 3.12
+      uses: actions/setup-python@v3
+      with:
+        python-version: '3.12'
+        architecture: 'x64'
+    - run: |
+        .\.github\workflows\python_build_win.ps1
+        .\.github\workflows\python_test_win.ps1
+
+    - name: Build and Test Python 3.13
+      uses: actions/setup-python@v3
+      with:
+        python-version: '3.13'
         architecture: 'x64'
     - run: |
         .\.github\workflows\python_build_win.ps1


### PR DESCRIPTION
Hello, 

Regarding an issue I have previously raised. (https://github.com/flatironinstitute/FMM3D/issues/64)

I have added python 3.12 and python 3.13 support in the github action commands.
I have closely followed a previous [commit](https://github.com/flatironinstitute/FMM3D/commit/94317b6a37c5a2541535767ea300008ccae22a09) in the repo which added support for 3.10 and 3.11 versions. 


Looking forward to your comments and feedbacks

Best regards,
Mohammad