### PR TITLE
Reduce Helmholtz memory usage

### DIFF
--- a/matlab/fmm3d.c
+++ b/matlab/fmm3d.c
@@ -1174,7 +1174,7 @@ extern "C" { /* Prevent C++ name mangling */
 #define MWF77_RETURN int
 #endif
 
-MWF77_RETURN MWF77_hndiv(double*, int64_t*, int64_t*, int64_t*, int64_t*, int64_t*, int64_t*, int64_t*, int64_t*);
+MWF77_RETURN MWF77_hndiv(double*, double*, int64_t*, int64_t*, int64_t*, int64_t*, int64_t*, int64_t*, int64_t*, int64_t*);
 MWF77_RETURN MWF77_hfmm3d_ndiv(int64_t*, double*, dcomplex*, int64_t*, double*, int64_t*, dcomplex*, int64_t*, dcomplex*, int64_t*, int64_t*, dcomplex*, dcomplex*, dcomplex*, int64_t*, double*, int64_t*, dcomplex*, dcomplex*, dcomplex*, int64_t*, int64_t*, int64_t*, double*, int64_t*);
 MWF77_RETURN MWF77_h3ddirectcp(int64_t*, dcomplex*, double*, dcomplex*, int64_t*, double*, int64_t*, dcomplex*, double*);
 MWF77_RETURN MWF77_h3ddirectdp(int64_t*, dcomplex*, double*, dcomplex*, int64_t*, double*, int64_t*, dcomplex*, double*);
@@ -1202,25 +1202,25 @@ MWF77_RETURN MWF77_st3ddirectstokstrsrotdoubg(int64_t*, double*, double*, int64_
 } /* end extern C */
 #endif
 
-/* ---- fmm3d.mw: 181 ----
- * hndiv(double[1] eps, int64_t[1] ns, int64_t[1] nt, int64_t[1] ifcharge, int64_t[1] ifdipole, int64_t[1] pg, int64_t[1] pgt, inout int64_t[1] ndiv, inout int64_t[1] idivflag);
+/* ---- fmm3d.mw: 187 ----
+ * hndiv(double[1] dbsize, double[1] eps, int64_t[1] ns, int64_t[1] nt, int64_t[1] ifcharge, int64_t[1] ifdipole, int64_t[1] pg, int64_t[1] pgt, inout int64_t[1] ndiv, inout int64_t[1] idivflag);
  */
-static const char* stubids1_ = "hndiv(i double[x], i int64_t[x], i int64_t[x], i int64_t[x], i int64_t[x], i int64_t[x], i int64_t[x], io int64_t[x], io int64_t[x])";
+static const char* stubids1_ = "hndiv(i double[x], i double[x], i int64_t[x], i int64_t[x], i int64_t[x], i int64_t[x], i int64_t[x], i int64_t[x], io int64_t[x], io int64_t[x])";
 
 void mexStub1(int nlhs, mxArray* plhs[],
               int nrhs, const mxArray* prhs[])
 {
     const char* mw_err_txt_ = 0;
-    double*     in0_ =0; /* eps        */
-    int64_t*    in1_ =0; /* ns         */
-    int64_t*    in2_ =0; /* nt         */
-    int64_t*    in3_ =0; /* ifcharge   */
-    int64_t*    in4_ =0; /* ifdipole   */
-    int64_t*    in5_ =0; /* pg         */
-    int64_t*    in6_ =0; /* pgt        */
-    int64_t*    in7_ =0; /* ndiv       */
-    int64_t*    in8_ =0; /* idivflag   */
-    mwSize      dim9_;   /* 1          */
+    double*     in0_ =0; /* dbsize     */
+    double*     in1_ =0; /* eps        */
+    int64_t*    in2_ =0; /* ns         */
+    int64_t*    in3_ =0; /* nt         */
+    int64_t*    in4_ =0; /* ifcharge   */
+    int64_t*    in5_ =0; /* ifdipole   */
+    int64_t*    in6_ =0; /* pg         */
+    int64_t*    in7_ =0; /* pgt        */
+    int64_t*    in8_ =0; /* ndiv       */
+    int64_t*    in9_ =0; /* idivflag   */
     mwSize      dim10_;   /* 1          */
     mwSize      dim11_;   /* 1          */
     mwSize      dim12_;   /* 1          */
@@ -1229,8 +1229,9 @@ void mexStub1(int nlhs, mxArray* plhs[],
     mwSize      dim15_;   /* 1          */
     mwSize      dim16_;   /* 1          */
     mwSize      dim17_;   /* 1          */
+    mwSize      dim18_;   /* 1          */
+    mwSize      dim19_;   /* 1          */
 
-    dim9_ = (mwSize) mxWrapGetScalar(prhs[9], &mw_err_txt_);
     dim10_ = (mwSize) mxWrapGetScalar(prhs[10], &mw_err_txt_);
     dim11_ = (mwSize) mxWrapGetScalar(prhs[11], &mw_err_txt_);
     dim12_ = (mwSize) mxWrapGetScalar(prhs[12], &mw_err_txt_);
@@ -1239,40 +1240,46 @@ void mexStub1(int nlhs, mxArray* plhs[],
     dim15_ = (mwSize) mxWrapGetScalar(prhs[15], &mw_err_txt_);
     dim16_ = (mwSize) mxWrapGetScalar(prhs[16], &mw_err_txt_);
     dim17_ = (mwSize) mxWrapGetScalar(prhs[17], &mw_err_txt_);
+    dim18_ = (mwSize) mxWrapGetScalar(prhs[18], &mw_err_txt_);
+    dim19_ = (mwSize) mxWrapGetScalar(prhs[19], &mw_err_txt_);
 
-    if (mxGetM(prhs[0])*mxGetN(prhs[0]) != dim9_) {
+    if (mxGetM(prhs[0])*mxGetN(prhs[0]) != dim10_) {
+        mw_err_txt_ = "Bad argument size: dbsize";        goto mw_err_label;
+    }
+
+    if (mxGetM(prhs[1])*mxGetN(prhs[1]) != dim11_) {
         mw_err_txt_ = "Bad argument size: eps";        goto mw_err_label;
     }
 
-    if (mxGetM(prhs[1])*mxGetN(prhs[1]) != dim10_) {
+    if (mxGetM(prhs[2])*mxGetN(prhs[2]) != dim12_) {
         mw_err_txt_ = "Bad argument size: ns";        goto mw_err_label;
     }
 
-    if (mxGetM(prhs[2])*mxGetN(prhs[2]) != dim11_) {
+    if (mxGetM(prhs[3])*mxGetN(prhs[3]) != dim13_) {
         mw_err_txt_ = "Bad argument size: nt";        goto mw_err_label;
     }
 
-    if (mxGetM(prhs[3])*mxGetN(prhs[3]) != dim12_) {
+    if (mxGetM(prhs[4])*mxGetN(prhs[4]) != dim14_) {
         mw_err_txt_ = "Bad argument size: ifcharge";        goto mw_err_label;
     }
 
-    if (mxGetM(prhs[4])*mxGetN(prhs[4]) != dim13_) {
+    if (mxGetM(prhs[5])*mxGetN(prhs[5]) != dim15_) {
         mw_err_txt_ = "Bad argument size: ifdipole";        goto mw_err_label;
     }
 
-    if (mxGetM(prhs[5])*mxGetN(prhs[5]) != dim14_) {
+    if (mxGetM(prhs[6])*mxGetN(prhs[6]) != dim16_) {
         mw_err_txt_ = "Bad argument size: pg";        goto mw_err_label;
     }
 
-    if (mxGetM(prhs[6])*mxGetN(prhs[6]) != dim15_) {
+    if (mxGetM(prhs[7])*mxGetN(prhs[7]) != dim17_) {
         mw_err_txt_ = "Bad argument size: pgt";        goto mw_err_label;
     }
 
-    if (mxGetM(prhs[7])*mxGetN(prhs[7]) != dim16_) {
+    if (mxGetM(prhs[8])*mxGetN(prhs[8]) != dim18_) {
         mw_err_txt_ = "Bad argument size: ndiv";        goto mw_err_label;
     }
 
-    if (mxGetM(prhs[8])*mxGetN(prhs[8]) != dim17_) {
+    if (mxGetM(prhs[9])*mxGetN(prhs[9]) != dim19_) {
         mw_err_txt_ = "Bad argument size: idivflag";        goto mw_err_label;
     }
 
@@ -1288,9 +1295,14 @@ void mexStub1(int nlhs, mxArray* plhs[],
     } else
         in0_ = NULL;
     if (mxGetM(prhs[1])*mxGetN(prhs[1]) != 0) {
-        in1_ = mxWrapGetArray_int64_t(prhs[1], &mw_err_txt_);
-        if (mw_err_txt_)
-            goto mw_err_label;
+        if( mxGetClassID(prhs[1]) != mxDOUBLE_CLASS )
+            mw_err_txt_ = "Invalid array argument, mxDOUBLE_CLASS expected";
+        if (mw_err_txt_) goto mw_err_label;
+#if MX_HAS_INTERLEAVED_COMPLEX
+        in1_ = mxGetDoubles(prhs[1]);
+#else
+        in1_ = mxGetPr(prhs[1]);
+#endif
     } else
         in1_ = NULL;
     if (mxGetM(prhs[2])*mxGetN(prhs[2]) != 0) {
@@ -1335,16 +1347,21 @@ void mexStub1(int nlhs, mxArray* plhs[],
             goto mw_err_label;
     } else
         in8_ = NULL;
+    if (mxGetM(prhs[9])*mxGetN(prhs[9]) != 0) {
+        in9_ = mxWrapGetArray_int64_t(prhs[9], &mw_err_txt_);
+        if (mw_err_txt_)
+            goto mw_err_label;
+    } else
+        in9_ = NULL;
     if (mexprofrecord_)
         mexprofrecord_[1]++;
-    MWF77_hndiv(in0_, in1_, in2_, in3_, in4_, in5_, in6_, in7_, in8_);
-    plhs[0] = mxCreateDoubleMatrix(dim16_, 1, mxREAL);
-    mxWrapCopy_int64_t(plhs[0], in7_, dim16_);
-    plhs[1] = mxCreateDoubleMatrix(dim17_, 1, mxREAL);
-    mxWrapCopy_int64_t(plhs[1], in8_, dim17_);
+    MWF77_hndiv(in0_, in1_, in2_, in3_, in4_, in5_, in6_, in7_, in8_, in9_);
+    plhs[0] = mxCreateDoubleMatrix(dim18_, 1, mxREAL);
+    mxWrapCopy_int64_t(plhs[0], in8_, dim18_);
+    plhs[1] = mxCreateDoubleMatrix(dim19_, 1, mxREAL);
+    mxWrapCopy_int64_t(plhs[1], in9_, dim19_);
 
 mw_err_label:
-    if (in1_)  mxFree(in1_);
     if (in2_)  mxFree(in2_);
     if (in3_)  mxFree(in3_);
     if (in4_)  mxFree(in4_);
@@ -1352,11 +1369,12 @@ mw_err_label:
     if (in6_)  mxFree(in6_);
     if (in7_)  mxFree(in7_);
     if (in8_)  mxFree(in8_);
+    if (in9_)  mxFree(in9_);
     if (mw_err_txt_)
         mexErrMsgTxt(mw_err_txt_);
 }
 
-/* ---- fmm3d.mw: 196 ----
+/* ---- fmm3d.mw: 202 ----
  * hfmm3d_ndiv(int64_t[1] nd, double[1] eps, dcomplex[1] zk, int64_t[1] ns, double[3, ns] sources, int64_t[1] ifcharge, dcomplex[nd, ns] charges, int64_t[1] ifdipole, dcomplex[nd3, ns] dipoles, int64_t[1] iper, int64_t[1] pg, inout dcomplex[nd, ns] pot, inout dcomplex[nd3, ns] grad, inout dcomplex[nd6, ns] hess, int64_t[1] nt, double[3, ntuse] targ, int64_t[1] pgt, inout dcomplex[nd, ntuse] pottarg, inout dcomplex[nd3, ntuse] gradtarg, inout dcomplex[nd6, ntuse] hesstarg, int64_t[1] ndiv, int64_t[1] idivflag, int64_t[1] ifnear, inout double[6] timeinfo, inout int64_t[1] ier);
  */
 static const char* stubids2_ = "hfmm3d_ndiv(i int64_t[x], i double[x], i dcomplex[x], i int64_t[x], i double[xx], i int64_t[x], i dcomplex[xx], i int64_t[x], i dcomplex[xx], i int64_t[x], i int64_t[x], io dcomplex[xx], io dcomplex[xx], io dcomplex[xx], i int64_t[x], i double[xx], i int64_t[x], io dcomplex[xx], io dcomplex[xx], io dcomplex[xx], i int64_t[x], i int64_t[x], i int64_t[x], io double[x], io int64_t[x])";
@@ -1821,7 +1839,7 @@ mw_err_label:
         mexErrMsgTxt(mw_err_txt_);
 }
 
-/* ---- fmm3d.mw: 278 ----
+/* ---- fmm3d.mw: 284 ----
  * h3ddirectcp(int64_t[1] nd, dcomplex[1] zk, double[3, ns] sources, dcomplex[nd, ns] charges, int64_t[1] ns, double[3, nt] targ, int64_t[1] nt, inout dcomplex[nd, nt] pottarg, double[1] thresh);
  */
 static const char* stubids3_ = "h3ddirectcp(i int64_t[x], i dcomplex[x], i double[xx], i dcomplex[xx], i int64_t[x], i double[xx], i int64_t[x], io dcomplex[xx], i double[x])";
@@ -2006,7 +2024,7 @@ mw_err_label:
         mexErrMsgTxt(mw_err_txt_);
 }
 
-/* ---- fmm3d.mw: 281 ----
+/* ---- fmm3d.mw: 287 ----
  * h3ddirectdp(int64_t[1] nd, dcomplex[1] zk, double[3, ns] sources, dcomplex[nd3, ns] dipoles, int64_t[1] ns, double[3, nt] targ, int64_t[1] nt, inout dcomplex[nd, nt] pottarg, double[1] thresh);
  */
 static const char* stubids4_ = "h3ddirectdp(i int64_t[x], i dcomplex[x], i double[xx], i dcomplex[xx], i int64_t[x], i double[xx], i int64_t[x], io dcomplex[xx], i double[x])";
@@ -2191,7 +2209,7 @@ mw_err_label:
         mexErrMsgTxt(mw_err_txt_);
 }
 
-/* ---- fmm3d.mw: 284 ----
+/* ---- fmm3d.mw: 290 ----
  * h3ddirectcdp(int64_t[1] nd, dcomplex[1] zk, double[3, ns] sources, dcomplex[nd, ns] charges, dcomplex[nd3, ns] dipoles, int64_t[1] ns, double[3, nt] targ, int64_t[1] nt, inout dcomplex[nd, nt] pottarg, double[1] thresh);
  */
 static const char* stubids5_ = "h3ddirectcdp(i int64_t[x], i dcomplex[x], i double[xx], i dcomplex[xx], i dcomplex[xx], i int64_t[x], i double[xx], i int64_t[x], io dcomplex[xx], i double[x])";
@@ -2397,7 +2415,7 @@ mw_err_label:
         mexErrMsgTxt(mw_err_txt_);
 }
 
-/* ---- fmm3d.mw: 290 ----
+/* ---- fmm3d.mw: 296 ----
  * h3ddirectcg(int64_t[1] nd, dcomplex[1] zk, double[3, ns] sources, dcomplex[nd, ns] charges, int64_t[1] ns, double[3, nt] targ, int64_t[1] nt, inout dcomplex[nd, nt] pottarg, inout dcomplex[nd3, nt] gradtarg, double[1] thresh);
  */
 static const char* stubids6_ = "h3ddirectcg(i int64_t[x], i dcomplex[x], i double[xx], i dcomplex[xx], i int64_t[x], i double[xx], i int64_t[x], io dcomplex[xx], io dcomplex[xx], i double[x])";
@@ -2605,7 +2623,7 @@ mw_err_label:
         mexErrMsgTxt(mw_err_txt_);
 }
 
-/* ---- fmm3d.mw: 293 ----
+/* ---- fmm3d.mw: 299 ----
  * h3ddirectdg(int64_t[1] nd, dcomplex[1] zk, double[3, ns] sources, dcomplex[nd3, ns] dipoles, int64_t[1] ns, double[3, nt] targ, int64_t[1] nt, inout dcomplex[nd, nt] pottarg, inout dcomplex[nd3, nt] gradtarg, double[1] thresh);
  */
 static const char* stubids7_ = "h3ddirectdg(i int64_t[x], i dcomplex[x], i double[xx], i dcomplex[xx], i int64_t[x], i double[xx], i int64_t[x], io dcomplex[xx], io dcomplex[xx], i double[x])";
@@ -2813,7 +2831,7 @@ mw_err_label:
         mexErrMsgTxt(mw_err_txt_);
 }
 
-/* ---- fmm3d.mw: 296 ----
+/* ---- fmm3d.mw: 302 ----
  * h3ddirectcdg(int64_t[1] nd, dcomplex[1] zk, double[3, ns] sources, dcomplex[nd, ns] charges, dcomplex[nd3, ns] dipoles, int64_t[1] ns, double[3, nt] targ, int64_t[1] nt, inout dcomplex[nd, nt] pottarg, inout dcomplex[nd3, nt] gradtarg, double[1] thresh);
  */
 static const char* stubids8_ = "h3ddirectcdg(i int64_t[x], i dcomplex[x], i double[xx], i dcomplex[xx], i dcomplex[xx], i int64_t[x], i double[xx], i int64_t[x], io dcomplex[xx], io dcomplex[xx], i double[x])";
@@ -3042,7 +3060,7 @@ mw_err_label:
         mexErrMsgTxt(mw_err_txt_);
 }
 
-/* ---- fmm3d.mw: 485 ----
+/* ---- fmm3d.mw: 491 ----
  * lndiv(double[1] eps, int64_t[1] ns, int64_t[1] nt, int64_t[1] ifcharge, int64_t[1] ifdipole, int64_t[1] pg, int64_t[1] pgt, inout int64_t[1] ndiv, inout int64_t[1] idivflag);
  */
 static const char* stubids9_ = "lndiv(i double[x], i int64_t[x], i int64_t[x], i int64_t[x], i int64_t[x], i int64_t[x], i int64_t[x], io int64_t[x], io int64_t[x])";
@@ -3196,7 +3214,7 @@ mw_err_label:
         mexErrMsgTxt(mw_err_txt_);
 }
 
-/* ---- fmm3d.mw: 500 ----
+/* ---- fmm3d.mw: 506 ----
  * lfmm3d_ndiv(int64_t[1] nd, double[1] eps, int64_t[1] ns, double[3, ns] sources, int64_t[1] ifcharge, double[nd, ns] charges, int64_t[1] ifdipole, double[nd3, ns] dipoles, int64_t[1] iper, int64_t[1] pg, inout double[nd, ns] pot, inout double[nd3, ns] grad, inout double[nd6, ns] hess, int64_t[1] nt, double[3, ntuse] targ, int64_t[1] pgt, inout double[nd, ntuse] pottarg, inout double[nd3, ntuse] gradtarg, inout double[nd6, ntuse] hesstarg, int64_t[1] ndiv, int64_t[1] idivflag, int64_t[1] ifnear, inout double[6] timeinfo, inout int64_t[1] ier);
  */
 static const char* stubids10_ = "lfmm3d_ndiv(i int64_t[x], i double[x], i int64_t[x], i double[xx], i int64_t[x], i double[xx], i int64_t[x], i double[xx], i int64_t[x], i int64_t[x], io double[xx], io double[xx], io double[xx], i int64_t[x], i double[xx], i int64_t[x], io double[xx], io double[xx], io double[xx], i int64_t[x], i int64_t[x], i int64_t[x], io double[x], io int64_t[x])";
@@ -3628,7 +3646,7 @@ mw_err_label:
         mexErrMsgTxt(mw_err_txt_);
 }
 
-/* ---- fmm3d.mw: 587 ----
+/* ---- fmm3d.mw: 593 ----
  * l3ddirectcp(int64_t[1] nd, double[3, ns] sources, double[nd, ns] charges, int64_t[1] ns, double[3, nt] targ, int64_t[1] nt, inout double[nd, nt] pottarg, double[1] thresh);
  */
 static const char* stubids11_ = "l3ddirectcp(i int64_t[x], i double[xx], i double[xx], i int64_t[x], i double[xx], i int64_t[x], io double[xx], i double[x])";
@@ -3794,7 +3812,7 @@ mw_err_label:
         mexErrMsgTxt(mw_err_txt_);
 }
 
-/* ---- fmm3d.mw: 590 ----
+/* ---- fmm3d.mw: 596 ----
  * l3ddirectdp(int64_t[1] nd, double[3, ns] sources, double[nd3, ns] dipoles, int64_t[1] ns, double[3, nt] targ, int64_t[1] nt, inout double[nd, nt] pottarg, double[1] thresh);
  */
 static const char* stubids12_ = "l3ddirectdp(i int64_t[x], i double[xx], i double[xx], i int64_t[x], i double[xx], i int64_t[x], io double[xx], i double[x])";
@@ -3960,7 +3978,7 @@ mw_err_label:
         mexErrMsgTxt(mw_err_txt_);
 }
 
-/* ---- fmm3d.mw: 593 ----
+/* ---- fmm3d.mw: 599 ----
  * l3ddirectcdp(int64_t[1] nd, double[3, ns] sources, double[nd, ns] charges, double[nd3, ns] dipoles, int64_t[1] ns, double[3, nt] targ, int64_t[1] nt, inout double[nd, nt] pottarg, double[1] thresh);
  */
 static const char* stubids13_ = "l3ddirectcdp(i int64_t[x], i double[xx], i double[xx], i double[xx], i int64_t[x], i double[xx], i int64_t[x], io double[xx], i double[x])";
@@ -4148,7 +4166,7 @@ mw_err_label:
         mexErrMsgTxt(mw_err_txt_);
 }
 
-/* ---- fmm3d.mw: 599 ----
+/* ---- fmm3d.mw: 605 ----
  * l3ddirectcg(int64_t[1] nd, double[3, ns] sources, double[nd, ns] charges, int64_t[1] ns, double[3, nt] targ, int64_t[1] nt, inout double[nd, nt] pottarg, inout double[nd3, nt] gradtarg, double[1] thresh);
  */
 static const char* stubids14_ = "l3ddirectcg(i int64_t[x], i double[xx], i double[xx], i int64_t[x], i double[xx], i int64_t[x], io double[xx], io double[xx], i double[x])";
@@ -4334,7 +4352,7 @@ mw_err_label:
         mexErrMsgTxt(mw_err_txt_);
 }
 
-/* ---- fmm3d.mw: 602 ----
+/* ---- fmm3d.mw: 608 ----
  * l3ddirectdg(int64_t[1] nd, double[3, ns] sources, double[nd3, ns] dipoles, int64_t[1] ns, double[3, nt] targ, int64_t[1] nt, inout double[nd, nt] pottarg, inout double[nd3, nt] gradtarg, double[1] thresh);
  */
 static const char* stubids15_ = "l3ddirectdg(i int64_t[x], i double[xx], i double[xx], i int64_t[x], i double[xx], i int64_t[x], io double[xx], io double[xx], i double[x])";
@@ -4520,7 +4538,7 @@ mw_err_label:
         mexErrMsgTxt(mw_err_txt_);
 }
 
-/* ---- fmm3d.mw: 605 ----
+/* ---- fmm3d.mw: 611 ----
  * l3ddirectcdg(int64_t[1] nd, double[3, ns] sources, double[nd, ns] charges, double[nd3, ns] dipoles, int64_t[1] ns, double[3, nt] targ, int64_t[1] nt, inout double[nd, nt] pottarg, inout double[nd3, nt] gradtarg, double[1] thresh);
  */
 static const char* stubids16_ = "l3ddirectcdg(i int64_t[x], i double[xx], i double[xx], i double[xx], i int64_t[x], i double[xx], i int64_t[x], io double[xx], io double[xx], i double[x])";
@@ -4728,7 +4746,7 @@ mw_err_label:
         mexErrMsgTxt(mw_err_txt_);
 }
 
-/* ---- fmm3d.mw: 612 ----
+/* ---- fmm3d.mw: 618 ----
  * l3ddirectch(int64_t[1] nd, double[3, ns] sources, double[nd, ns] charges, int64_t[1] ns, double[3, nt] targ, int64_t[1] nt, inout double[nd, nt] pottarg, inout double[nd3, nt] gradtarg, inout double[nd6, nt] hesstarg, double[1] thresh);
  */
 static const char* stubids17_ = "l3ddirectch(i int64_t[x], i double[xx], i double[xx], i int64_t[x], i double[xx], i int64_t[x], io double[xx], io double[xx], io double[xx], i double[x])";
@@ -4934,7 +4952,7 @@ mw_err_label:
         mexErrMsgTxt(mw_err_txt_);
 }
 
-/* ---- fmm3d.mw: 615 ----
+/* ---- fmm3d.mw: 621 ----
  * l3ddirectdh(int64_t[1] nd, double[3, ns] sources, double[nd3, ns] dipoles, int64_t[1] ns, double[3, nt] targ, int64_t[1] nt, inout double[nd, nt] pottarg, inout double[nd3, nt] gradtarg, inout double[nd6, nt] hesstarg, double[1] thresh);
  */
 static const char* stubids18_ = "l3ddirectdh(i int64_t[x], i double[xx], i double[xx], i int64_t[x], i double[xx], i int64_t[x], io double[xx], io double[xx], io double[xx], i double[x])";
@@ -5140,7 +5158,7 @@ mw_err_label:
         mexErrMsgTxt(mw_err_txt_);
 }
 
-/* ---- fmm3d.mw: 618 ----
+/* ---- fmm3d.mw: 624 ----
  * l3ddirectcdh(int64_t[1] nd, double[3, ns] sources, double[nd, ns] charges, double[nd3, ns] dipoles, int64_t[1] ns, double[3, nt] targ, int64_t[1] nt, inout double[nd, nt] pottarg, inout double[nd3, nt] gradtarg, inout double[nd6, nt] hesstarg, double[1] thresh);
  */
 static const char* stubids19_ = "l3ddirectcdh(i int64_t[x], i double[xx], i double[xx], i double[xx], i int64_t[x], i double[xx], i int64_t[x], io double[xx], io double[xx], io double[xx], i double[x])";
@@ -5368,7 +5386,7 @@ mw_err_label:
         mexErrMsgTxt(mw_err_txt_);
 }
 
-/* ---- fmm3d.mw: 779 ----
+/* ---- fmm3d.mw: 785 ----
  * emfmm3d(int64_t[1] nd, double[1] eps, dcomplex[1] zk, int64_t[1] ns, double[3, ns] sources, int64_t[1] ifh_current, dcomplex[nd3, ns_h_current] h_current, int64_t[1] ife_current, dcomplex[nd3, ns_e_current] e_current, int64_t[1] ife_charge, dcomplex[nd, ns_e_charge] e_charge, int64_t[1] nt, double[3, nt] targ, int64_t[1] ifE, inout dcomplex[nd3, nt_E] E, int64_t[1] ifcurlE, inout dcomplex[nd3, nt_curlE] curlE, int64_t[1] ifdivE, inout dcomplex[nd, nt_divE] divE, inout int64_t[1] ier);
  */
 static const char* stubids20_ = "emfmm3d(i int64_t[x], i double[x], i dcomplex[x], i int64_t[x], i double[xx], i int64_t[x], i dcomplex[xx], i int64_t[x], i dcomplex[xx], i int64_t[x], i dcomplex[xx], i int64_t[x], i double[xx], i int64_t[x], io dcomplex[xx], i int64_t[x], io dcomplex[xx], i int64_t[x], io dcomplex[xx], io int64_t[x])";
@@ -5741,7 +5759,7 @@ mw_err_label:
         mexErrMsgTxt(mw_err_txt_);
 }
 
-/* ---- fmm3d.mw: 886 ----
+/* ---- fmm3d.mw: 892 ----
  * em3ddirect(int64_t[1] nd, dcomplex[1] zk, int64_t[1] ns, double[3, ns] sources, int64_t[1] ifh_current, dcomplex[nd3, ns_h_current] h_current, int64_t[1] ife_current, dcomplex[nd3, ns_e_current] e_current, int64_t[1] ife_charge, dcomplex[nd, ns_e_charge] e_charge, int64_t[1] nt, double[3, nt] targ, int64_t[1] ifE, inout dcomplex[nd3, nt_E] E, int64_t[1] ifcurlE, inout dcomplex[nd3, nt_curlE] curlE, int64_t[1] ifdivE, inout dcomplex[nd, nt_divE] divE, double[1] thresh);
  */
 static const char* stubids21_ = "em3ddirect(i int64_t[x], i dcomplex[x], i int64_t[x], i double[xx], i int64_t[x], i dcomplex[xx], i int64_t[x], i dcomplex[xx], i int64_t[x], i dcomplex[xx], i int64_t[x], i double[xx], i int64_t[x], io dcomplex[xx], i int64_t[x], io dcomplex[xx], i int64_t[x], io dcomplex[xx], i double[x])";
@@ -6098,7 +6116,7 @@ mw_err_label:
         mexErrMsgTxt(mw_err_txt_);
 }
 
-/* ---- fmm3d.mw: 1134 ----
+/* ---- fmm3d.mw: 1140 ----
  * stfmm3d(int64_t[1] nd, double[1] eps, int64_t[1] ns, double[3, ns] sources, int64_t[1] ifstoklet, double[nd3, ns_stok] stoklet, int64_t[1] ifstrslet, double[nd3, ns_strs] strslet, double[nd3, ns_strs] strsvec, int64_t[1] ifrotlet, double[nd3, ns_rot] rotlet, double[nd3, ns_rot] rotvec, int64_t[1] ifdoublet, double[nd3, ns_doub] doublet, double[nd3, ns_doub] doubvec, int64_t[1] ifppreg, inout double[nd3, ns_pot] pot, inout double[nd, ns_pre] pre, inout double[nd9, ns_grad] grad, int64_t[1] nt, double[3, nt] targ, int64_t[1] ifppregtarg, inout double[nd3, nt_pot] pottarg, inout double[nd, nt_pre] pretarg, inout double[nd9, nt_grad] gradtarg, inout int64_t[1] ier);
  */
 static const char* stubids22_ = "stfmm3d(i int64_t[x], i double[x], i int64_t[x], i double[xx], i int64_t[x], i double[xx], i int64_t[x], i double[xx], i double[xx], i int64_t[x], i double[xx], i double[xx], i int64_t[x], i double[xx], i double[xx], i int64_t[x], io double[xx], io double[xx], io double[xx], i int64_t[x], i double[xx], i int64_t[x], io double[xx], io double[xx], io double[xx], io int64_t[x])";
@@ -6596,7 +6614,7 @@ mw_err_label:
         mexErrMsgTxt(mw_err_txt_);
 }
 
-/* ---- fmm3d.mw: 1266 ----
+/* ---- fmm3d.mw: 1272 ----
  * st3ddirectstokstrsrotdoubg(int64_t[1] nd, double[3, ns] sources, double[nd3, ns_stok] stoklet, int64_t[1] ifstrslet, double[nd3, ns_strs] strslet, double[nd3, ns_strs] strsvec, int64_t[1] ifrotlet, double[nd3, ns_rot] rotlet, double[nd3, ns_rot] rotvec, int64_t[1] ifdoublet, double[nd3, ns_doub] doublet, double[nd3, ns_doub] doubvec, int64_t[1] ns, double[3, nt] targ, int64_t[1] nt, inout double[nd3, nt] pottarg, inout double[nd, nt] pretarg, inout double[nd9, nt] gradtarg, double[1] thresh);
  */
 static const char* stubids23_ = "st3ddirectstokstrsrotdoubg(i int64_t[x], i double[xx], i double[xx], i int64_t[x], i double[xx], i double[xx], i int64_t[x], i double[xx], i double[xx], i int64_t[x], i double[xx], i double[xx], i int64_t[x], i double[xx], i int64_t[x], io double[xx], io double[xx], io double[xx], i double[x])";
@@ -7050,29 +7068,29 @@ void mexFunction(int nlhs, mxArray* plhs[],
     } else if (strcmp(id, "*profile report*") == 0) {
         if (!mexprofrecord_)
             mexPrintf("Profiler inactive\n");
-        mexPrintf("%d calls to fmm3d.mw:181\n", mexprofrecord_[1]);
-        mexPrintf("%d calls to fmm3d.mw:196\n", mexprofrecord_[2]);
-        mexPrintf("%d calls to fmm3d.mw:278\n", mexprofrecord_[3]);
-        mexPrintf("%d calls to fmm3d.mw:281\n", mexprofrecord_[4]);
-        mexPrintf("%d calls to fmm3d.mw:284\n", mexprofrecord_[5]);
-        mexPrintf("%d calls to fmm3d.mw:290\n", mexprofrecord_[6]);
-        mexPrintf("%d calls to fmm3d.mw:293\n", mexprofrecord_[7]);
-        mexPrintf("%d calls to fmm3d.mw:296\n", mexprofrecord_[8]);
-        mexPrintf("%d calls to fmm3d.mw:485\n", mexprofrecord_[9]);
-        mexPrintf("%d calls to fmm3d.mw:500\n", mexprofrecord_[10]);
-        mexPrintf("%d calls to fmm3d.mw:587\n", mexprofrecord_[11]);
-        mexPrintf("%d calls to fmm3d.mw:590\n", mexprofrecord_[12]);
-        mexPrintf("%d calls to fmm3d.mw:593\n", mexprofrecord_[13]);
-        mexPrintf("%d calls to fmm3d.mw:599\n", mexprofrecord_[14]);
-        mexPrintf("%d calls to fmm3d.mw:602\n", mexprofrecord_[15]);
-        mexPrintf("%d calls to fmm3d.mw:605\n", mexprofrecord_[16]);
-        mexPrintf("%d calls to fmm3d.mw:612\n", mexprofrecord_[17]);
-        mexPrintf("%d calls to fmm3d.mw:615\n", mexprofrecord_[18]);
-        mexPrintf("%d calls to fmm3d.mw:618\n", mexprofrecord_[19]);
-        mexPrintf("%d calls to fmm3d.mw:779\n", mexprofrecord_[20]);
-        mexPrintf("%d calls to fmm3d.mw:886\n", mexprofrecord_[21]);
-        mexPrintf("%d calls to fmm3d.mw:1134\n", mexprofrecord_[22]);
-        mexPrintf("%d calls to fmm3d.mw:1266\n", mexprofrecord_[23]);
+        mexPrintf("%d calls to fmm3d.mw:187\n", mexprofrecord_[1]);
+        mexPrintf("%d calls to fmm3d.mw:202\n", mexprofrecord_[2]);
+        mexPrintf("%d calls to fmm3d.mw:284\n", mexprofrecord_[3]);
+        mexPrintf("%d calls to fmm3d.mw:287\n", mexprofrecord_[4]);
+        mexPrintf("%d calls to fmm3d.mw:290\n", mexprofrecord_[5]);
+        mexPrintf("%d calls to fmm3d.mw:296\n", mexprofrecord_[6]);
+        mexPrintf("%d calls to fmm3d.mw:299\n", mexprofrecord_[7]);
+        mexPrintf("%d calls to fmm3d.mw:302\n", mexprofrecord_[8]);
+        mexPrintf("%d calls to fmm3d.mw:491\n", mexprofrecord_[9]);
+        mexPrintf("%d calls to fmm3d.mw:506\n", mexprofrecord_[10]);
+        mexPrintf("%d calls to fmm3d.mw:593\n", mexprofrecord_[11]);
+        mexPrintf("%d calls to fmm3d.mw:596\n", mexprofrecord_[12]);
+        mexPrintf("%d calls to fmm3d.mw:599\n", mexprofrecord_[13]);
+        mexPrintf("%d calls to fmm3d.mw:605\n", mexprofrecord_[14]);
+        mexPrintf("%d calls to fmm3d.mw:608\n", mexprofrecord_[15]);
+        mexPrintf("%d calls to fmm3d.mw:611\n", mexprofrecord_[16]);
+        mexPrintf("%d calls to fmm3d.mw:618\n", mexprofrecord_[17]);
+        mexPrintf("%d calls to fmm3d.mw:621\n", mexprofrecord_[18]);
+        mexPrintf("%d calls to fmm3d.mw:624\n", mexprofrecord_[19]);
+        mexPrintf("%d calls to fmm3d.mw:785\n", mexprofrecord_[20]);
+        mexPrintf("%d calls to fmm3d.mw:892\n", mexprofrecord_[21]);
+        mexPrintf("%d calls to fmm3d.mw:1140\n", mexprofrecord_[22]);
+        mexPrintf("%d calls to fmm3d.mw:1272\n", mexprofrecord_[23]);
     } else if (strcmp(id, "*profile log*") == 0) {
         FILE* logfp;
         if (nrhs != 2 || mxGetString(prhs[1], id, sizeof(id)) != 0)
@@ -7082,29 +7100,29 @@ void mexFunction(int nlhs, mxArray* plhs[],
             mexErrMsgTxt("Cannot open log for output");
         if (!mexprofrecord_)
             fprintf(logfp, "Profiler inactive\n");
-        fprintf(logfp, "%d calls to fmm3d.mw:181\n", mexprofrecord_[1]);
-        fprintf(logfp, "%d calls to fmm3d.mw:196\n", mexprofrecord_[2]);
-        fprintf(logfp, "%d calls to fmm3d.mw:278\n", mexprofrecord_[3]);
-        fprintf(logfp, "%d calls to fmm3d.mw:281\n", mexprofrecord_[4]);
-        fprintf(logfp, "%d calls to fmm3d.mw:284\n", mexprofrecord_[5]);
-        fprintf(logfp, "%d calls to fmm3d.mw:290\n", mexprofrecord_[6]);
-        fprintf(logfp, "%d calls to fmm3d.mw:293\n", mexprofrecord_[7]);
-        fprintf(logfp, "%d calls to fmm3d.mw:296\n", mexprofrecord_[8]);
-        fprintf(logfp, "%d calls to fmm3d.mw:485\n", mexprofrecord_[9]);
-        fprintf(logfp, "%d calls to fmm3d.mw:500\n", mexprofrecord_[10]);
-        fprintf(logfp, "%d calls to fmm3d.mw:587\n", mexprofrecord_[11]);
-        fprintf(logfp, "%d calls to fmm3d.mw:590\n", mexprofrecord_[12]);
-        fprintf(logfp, "%d calls to fmm3d.mw:593\n", mexprofrecord_[13]);
-        fprintf(logfp, "%d calls to fmm3d.mw:599\n", mexprofrecord_[14]);
-        fprintf(logfp, "%d calls to fmm3d.mw:602\n", mexprofrecord_[15]);
-        fprintf(logfp, "%d calls to fmm3d.mw:605\n", mexprofrecord_[16]);
-        fprintf(logfp, "%d calls to fmm3d.mw:612\n", mexprofrecord_[17]);
-        fprintf(logfp, "%d calls to fmm3d.mw:615\n", mexprofrecord_[18]);
-        fprintf(logfp, "%d calls to fmm3d.mw:618\n", mexprofrecord_[19]);
-        fprintf(logfp, "%d calls to fmm3d.mw:779\n", mexprofrecord_[20]);
-        fprintf(logfp, "%d calls to fmm3d.mw:886\n", mexprofrecord_[21]);
-        fprintf(logfp, "%d calls to fmm3d.mw:1134\n", mexprofrecord_[22]);
-        fprintf(logfp, "%d calls to fmm3d.mw:1266\n", mexprofrecord_[23]);
+        fprintf(logfp, "%d calls to fmm3d.mw:187\n", mexprofrecord_[1]);
+        fprintf(logfp, "%d calls to fmm3d.mw:202\n", mexprofrecord_[2]);
+        fprintf(logfp, "%d calls to fmm3d.mw:284\n", mexprofrecord_[3]);
+        fprintf(logfp, "%d calls to fmm3d.mw:287\n", mexprofrecord_[4]);
+        fprintf(logfp, "%d calls to fmm3d.mw:290\n", mexprofrecord_[5]);
+        fprintf(logfp, "%d calls to fmm3d.mw:296\n", mexprofrecord_[6]);
+        fprintf(logfp, "%d calls to fmm3d.mw:299\n", mexprofrecord_[7]);
+        fprintf(logfp, "%d calls to fmm3d.mw:302\n", mexprofrecord_[8]);
+        fprintf(logfp, "%d calls to fmm3d.mw:491\n", mexprofrecord_[9]);
+        fprintf(logfp, "%d calls to fmm3d.mw:506\n", mexprofrecord_[10]);
+        fprintf(logfp, "%d calls to fmm3d.mw:593\n", mexprofrecord_[11]);
+        fprintf(logfp, "%d calls to fmm3d.mw:596\n", mexprofrecord_[12]);
+        fprintf(logfp, "%d calls to fmm3d.mw:599\n", mexprofrecord_[13]);
+        fprintf(logfp, "%d calls to fmm3d.mw:605\n", mexprofrecord_[14]);
+        fprintf(logfp, "%d calls to fmm3d.mw:608\n", mexprofrecord_[15]);
+        fprintf(logfp, "%d calls to fmm3d.mw:611\n", mexprofrecord_[16]);
+        fprintf(logfp, "%d calls to fmm3d.mw:618\n", mexprofrecord_[17]);
+        fprintf(logfp, "%d calls to fmm3d.mw:621\n", mexprofrecord_[18]);
+        fprintf(logfp, "%d calls to fmm3d.mw:624\n", mexprofrecord_[19]);
+        fprintf(logfp, "%d calls to fmm3d.mw:785\n", mexprofrecord_[20]);
+        fprintf(logfp, "%d calls to fmm3d.mw:892\n", mexprofrecord_[21]);
+        fprintf(logfp, "%d calls to fmm3d.mw:1140\n", mexprofrecord_[22]);
+        fprintf(logfp, "%d calls to fmm3d.mw:1272\n", mexprofrecord_[23]);
         fclose(logfp);
     } else
         mexErrMsgTxt("Unknown identifier");

--- a/matlab/fmm3d.mw
+++ b/matlab/fmm3d.mw
@@ -178,6 +178,12 @@
 
   ndiv = 400;
   idivflag = 0;
+
+  xyzmin = min(sources.');
+  xyzmax = max(sources.');
+  
+  bsize = max(xyzmax - xyzmin);
+  dbsize = bsize*real(zk)/2/pi;
   # FORTRAN hndiv(double[1] eps,int[1] ns,int[1] nt,int[1] ifcharge,int[1] ifdipole,int[1] pg, int[1] pgt, inout int[1] ndiv, inout int[1] idivflag); 
   if(isfield(opts,'ndiv'))
     ndiv = opts.ndiv;

--- a/matlab/fmm3d.mw
+++ b/matlab/fmm3d.mw
@@ -181,10 +181,10 @@
 
   xyzmin = min(sources.');
   xyzmax = max(sources.');
-  
+
   bsize = max(xyzmax - xyzmin);
   dbsize = bsize*real(zk)/2/pi;
-  # FORTRAN hndiv(double[1] eps,int[1] ns,int[1] nt,int[1] ifcharge,int[1] ifdipole,int[1] pg, int[1] pgt, inout int[1] ndiv, inout int[1] idivflag); 
+  # FORTRAN hndiv(double[1] dbsize,double[1] eps,int[1] ns,int[1] nt,int[1] ifcharge,int[1] ifdipole,int[1] pg, int[1] pgt, inout int[1] ndiv, inout int[1] idivflag);
   if(isfield(opts,'ndiv'))
     ndiv = opts.ndiv;
   end

--- a/matlab/hfmm3d.m
+++ b/matlab/hfmm3d.m
@@ -177,8 +177,14 @@ function [U,varargout] = hfmm3d(eps,zk,srcinfo,pg,varargin)
 
   ndiv = 400;
   idivflag = 0;
-  mex_id_ = 'hndiv(i double[x], i int64_t[x], i int64_t[x], i int64_t[x], i int64_t[x], i int64_t[x], i int64_t[x], io int64_t[x], io int64_t[x])';
-[ndiv, idivflag] = fmm3d(mex_id_, eps, ns, nt, ifcharge, ifdipole, pg, pgt, ndiv, idivflag, 1, 1, 1, 1, 1, 1, 1, 1, 1);
+
+  xyzmin = min(sources.');
+  xyzmax = max(sources.');
+
+  bsize = max(xyzmax - xyzmin);
+  dbsize = bsize*real(zk)/2/pi;
+  mex_id_ = 'hndiv(i double[x], i double[x], i int64_t[x], i int64_t[x], i int64_t[x], i int64_t[x], i int64_t[x], i int64_t[x], io int64_t[x], io int64_t[x])';
+[ndiv, idivflag] = fmm3d(mex_id_, dbsize, eps, ns, nt, ifcharge, ifdipole, pg, pgt, ndiv, idivflag, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1);
   if(isfield(opts,'ndiv'))
     ndiv = opts.ndiv;
   end

--- a/src/Helmholtz/hfmm3d.f
+++ b/src/Helmholtz/hfmm3d.f
@@ -135,6 +135,8 @@ c       Tree variables
       double precision, allocatable :: treecenters(:,:),boxsize(:)
       double precision b0,b0inv,b0inv2,b0inv3
       double complex zkfmm
+      double precision xmin, xmax, ymin, ymax, zmin, zmax, pi, dbsize
+      double precision bs0, sizey, sizez
 
 c
 cc      temporary sorted arrays
@@ -189,9 +191,55 @@ c
       ifnear = 1
 
 c
+c  Determine the computational boxsize
+c
+
+      xmin = source(1,1)
+      xmax = source(1,1)
+      ymin = source(2,1)
+      ymax = source(2,1)
+      zmin = source(3,1)
+      zmax = source(3,1)
+C$OMP PARALLEL DO DEFAULT(SHARED)
+C$OMP$REDUCTION(min:xmin,ymin,zmin)
+C$OMP$REDUCTION(max:xmax,ymax,zmax)
+      do i=1,nsource
+        if(source(1,i).lt.xmin) xmin = source(1,i)
+        if(source(1,i).gt.xmax) xmax = source(1,i)
+        if(source(2,i).lt.ymin) ymin = source(2,i)
+        if(source(2,i).gt.ymax) ymax = source(2,i)
+        if(source(3,i).lt.zmin) zmin = source(3,i)
+        if(source(3,i).gt.zmax) zmax = source(3,i)
+      enddo
+C$OMP END PARALLEL DO      
+
+C$OMP PARALLEL DO DEFAULT(SHARED)
+C$OMP$REDUCTION(min:xmin,ymin,zmin)
+C$OMP$REDUCTION(max:xmax,ymax,zmax)
+      do i=1,ntarg
+        if(targ(1,i).lt.xmin) xmin = targ(1,i)
+        if(targ(1,i).gt.xmax) xmax = targ(1,i)
+        if(targ(2,i).lt.ymin) ymin = targ(2,i)
+        if(targ(2,i).gt.ymax) ymax = targ(2,i)
+        if(targ(3,i).lt.zmin) zmin = targ(3,i)
+        if(targ(3,i).gt.zmax) zmax = targ(3,i)
+      enddo
+C$OMP END PARALLEL DO      
+
+      bs0 = (xmax - xmin)
+      sizey = (ymax - ymin)
+      sizez = (zmax - zmin)
+      if(sizey.gt.bs0) bs0 = sizey
+      if(sizez.gt.bs0) bs0 = sizez
+
+      pi = atan(1.0d0)*4.0d0
+
+      dbsize = real(zk)*bs0/2/pi
+      
+c
 cc        set criterion for box subdivision
 c
-      call hndiv(eps,nsource,ntarg,ifcharge,ifdipole,ifpgh,
+      call hndiv(dbsize,eps,nsource,ntarg,ifcharge,ifdipole,ifpgh,
      1   ifpghtarg,ndiv,idivflag) 
 
       nexpc = 0

--- a/src/Helmholtz/hndiv.f
+++ b/src/Helmholtz/hndiv.f
@@ -1,4 +1,4 @@
-      subroutine hndiv(eps,ns,nt,ifcharge,ifdipole,ifpgh,
+      subroutine hndiv(dbsize,eps,ns,nt,ifcharge,ifdipole,ifpgh,
      1   ifpghtarg,ndiv,idivflag)
 c
 c
@@ -9,31 +9,35 @@ c       TODO: better way to choose ndiv based on boxsize
 c
 c
       implicit none
-      real *8 eps
+      real *8 eps,dbsize,rfac
       integer *8 ns,nt,ifcharge,ifdipole,ifpgh,ifpghtarg,ndiv
       integer *8 idivflag
 
       idivflag = 0
+      rfac = 1.0d0
+      if (dbsize.gt.8) rfac = (dbsize/8)**1.5d0
 
        if(eps.ge.0.5d-0) then
-         ndiv = 40
+         ndiv = ceiling(40*rfac)
        else if(eps.ge.0.5d-1) then
-         ndiv = 40
+         ndiv = ceiling(40*rfac)
        else if(eps.ge.0.5d-2) then
-         ndiv = 40
+         ndiv = ceiling(40*rfac)
        else if(eps.ge.0.5d-3) then
-         ndiv = 80
+         ndiv = ceiling(120*rfac)
        else if(eps.ge.0.5d-6) then
-         ndiv = 200
+         ndiv = ceiling(300*rfac)
        else if(eps.ge.0.5d-9) then
-         ndiv = 400
+         ndiv = ceiling(600*rfac)
        else if(eps.ge.0.5d-12) then
-         ndiv = 600
+         ndiv = ceiling(900*rfac)
        else if(eps.ge.0.5d-15) then
-         ndiv = 700
+         ndiv = ceiling(1050*rfac)
        else
          ndiv = ns+nt
        endif
+
+       ndiv = min(ndiv,10000)
 
       return
       end

--- a/src/Helmholtz/hndiv_fast.f
+++ b/src/Helmholtz/hndiv_fast.f
@@ -1,4 +1,4 @@
-      subroutine hndiv(eps,ns,nt,ifcharge,ifdipole,ifpgh,
+      subroutine hndiv(dbsize,eps,ns,nt,ifcharge,ifdipole,ifpgh,
      1   ifpghtarg,ndiv,idivflag)
 c
 c
@@ -7,31 +7,36 @@ c       based on geometry parameters
 c       
 c
       implicit none
-      real *8 eps
+      real *8 eps,dbsize,rfac
       integer *8 ns,nt,ifcharge,ifdipole,ifpgh,ifpghtarg,ndiv
       integer *8 idivflag
 
       idivflag = 0
+      rfac = 1.0d0
+      if (dbsize.gt.8) rfac = (dbsize/8)**1.5d0
+      
 
        if(eps.ge.0.5d-0) then
-         ndiv = 300
+         ndiv = ceiling(300*rfac)
        else if(eps.ge.0.5d-1) then
-         ndiv = 300
+         ndiv = ceiling(300*rfac)
        else if(eps.ge.0.5d-2) then
-         ndiv = 300
+         ndiv = ceiling(300*rfac)
        else if(eps.ge.0.5d-3) then
-         ndiv = 300
+         ndiv = ceiling(300*rfac)
        else if(eps.ge.0.5d-6) then
-         ndiv = 1000
+         ndiv = ceiling(1000*rfac)
        else if(eps.ge.0.5d-9) then
-         ndiv = 1000
+         ndiv = ceiling(1000*rfac)
        else if(eps.ge.0.5d-12) then
-         ndiv = 1000
+         ndiv = ceiling(1000*rfac)
        else if(eps.ge.0.5d-15) then
-         ndiv = 1000
+         ndiv = ceiling(1000*rfac)
        else
          ndiv = ns+nt
        endif
+
+       ndiv = min(ndiv, 10000)
 
       return
       end

--- a/src/Helmholtz/hpwrouts.f
+++ b/src/Helmholtz/hpwrouts.f
@@ -798,7 +798,8 @@ c----------------------------------------------------------
      3           nu1234,u1234,ndall,dall,nd5678,d5678,mexpup,mexpdown,
      4           mexpupphys,mexpdownphys,mexpuall,mexpu5678,mexpdall,
      5           mexpd1234,xs,ys,zs,fexpback,rlsc,
-     6           pgboxwexp,cntlist4,list4,nlist4s,ilist4,mnlist4)
+     6           pgboxwexp,cntlist4,list4,nlist4s,ilist4,mnlist4,
+     7           nboxesilev,mexpoffset)
 c--------------------------------------------------------------------
 c      process up down expansions for box ibox
 c-------------------------------------------------------------------
@@ -815,7 +816,10 @@ c-------------------------------------------------------------------
        complex *16 zk2
        complex *16 rlams(*),whts(*)
        complex *16 tloc(nd,0:nterms,-nterms:nterms)
-       complex *16 mexp(nd,nexptotp,nboxes,6)
+       integer *8 nboxesilev
+       integer *8 mexpoffset
+       complex *16 mexp(nd,nexptotp,nboxesilev,6)
+c       complex *16 mexp(nd,nexptotp,nboxes,6)
        real *8 rmlexp(*),centers(3,*)
        complex *16 mexpup(nd,nexptot),mexpdown(nd,nexptot)
        complex *16 mexpupphys(nd,nexptotp),mexpdownphys(nd,nexptotp)
@@ -857,6 +861,7 @@ c      temp variables
           iy = 1.05d0*(centers(2,jbox)-ctmp(2))/bs
           iz = 1.05d0*(centers(3,jbox)-ctmp(3))/bs
          
+          jbox = jbox - mexpoffset
           do j=1,nexptotp
              zmul = zs(iz,j)*xs(ix,j)*ys(iy,j)
              do idim=1,nd
@@ -872,6 +877,7 @@ c      temp variables
           iy = 1.05d0*(centers(2,jbox)-ctmp(2))/bs
           iz = 1.05d0*(centers(3,jbox)-ctmp(3))/bs
 
+          jbox = jbox - mexpoffset
           do j=1,nexptotp
              zmul = zs(iz,j)*xs(ix,j)*ys(iy,j)
              do idim=1,nd
@@ -889,6 +895,7 @@ c      temp variables
           iz = 1.05d0*(centers(3,jbox)-ctmp(3))/bs
 
          
+          jbox = jbox - mexpoffset
           do j=1,nexptotp
              zmul = zs(-iz,j)*xs(-ix,j)*ys(-iy,j)
              do idim=1,nd
@@ -904,6 +911,7 @@ c      temp variables
           iy = 1.05d0*(centers(2,jbox)-ctmp(2))/bs
           iz = 1.05d0*(centers(3,jbox)-ctmp(3))/bs
          
+          jbox = jbox - mexpoffset
           do j=1,nexptotp
              zmul = zs(-iz,j)*xs(-ix,j)*ys(-iy,j)
              do idim=1,nd
@@ -1219,7 +1227,8 @@ c--------------------------------------------------------------------
      6           mexpnall,mexpn3478,mexpn34,mexpn78,mexpsall,
      7           mexps1256,mexps12,mexps56,rdplus,
      8           xs,ys,zs,fexpback,rlsc,
-     9           pgboxwexp,cntlist4,list4,nlist4s,ilist4,mnlist4)
+     9           pgboxwexp,cntlist4,list4,nlist4s,ilist4,mnlist4,
+     9           nboxesilev,mexpoffset)
 c--------------------------------------------------------------------
 c      process north south expansions for box ibox
 c-------------------------------------------------------------------
@@ -1238,7 +1247,10 @@ c-------------------------------------------------------------------
        complex *16 rlams(*),whts(*)
        complex *16 tloc(nd,0:nterms,-nterms:nterms)
        complex *16, allocatable :: tloc2(:,:,:)
-       complex *16 mexp(nd,nexptotp,nboxes,6)
+       integer *8 nboxesilev
+       integer *8 mexpoffset
+       complex *16 mexp(nd,nexptotp,nboxesilev,6)
+c       complex *16 mexp(nd,nexptotp,nboxes,6)
        real *8 rdplus(0:nterms,0:nterms,-nterms:nterms)
        real *8 rmlexp(*),centers(3,*)
        complex *16 mexpup(nd,nexptot),mexpdown(nd,nexptot)
@@ -1288,6 +1300,7 @@ c      temp variables
           iy = 1.05d0*(centers(2,jbox)-ctmp(2))/bs
           iz = 1.05d0*(centers(3,jbox)-ctmp(3))/bs
          
+          jbox = jbox - mexpoffset
           do j=1,nexptotp
              zmul = zs(iy,j)*xs(iz,j)*ys(ix,j)
              do idim=1,nd
@@ -1304,6 +1317,7 @@ c      temp variables
           iy = 1.05d0*(centers(2,jbox)-ctmp(2))/bs
           iz = 1.05d0*(centers(3,jbox)-ctmp(3))/bs
          
+          jbox = jbox - mexpoffset
           do j=1,nexptotp
              zmul = zs(iy,j)*xs(iz,j)*ys(ix,j)
              do idim=1,nd
@@ -1319,6 +1333,7 @@ c      temp variables
           iy = 1.05d0*(centers(2,jbox)-ctmp(2))/bs
           iz = 1.05d0*(centers(3,jbox)-ctmp(3))/bs
          
+          jbox = jbox - mexpoffset
           do j=1,nexptotp
              zmul = zs(iy,j)*xs(iz,j)*ys(ix,j)
              do idim=1,nd
@@ -1335,6 +1350,7 @@ c      temp variables
           iy = 1.05d0*(centers(2,jbox)-ctmp(2))/bs
           iz = 1.05d0*(centers(3,jbox)-ctmp(3))/bs
          
+          jbox = jbox - mexpoffset
           do j=1,nexptotp
              zmul = zs(iy,j)*xs(iz,j)*ys(ix,j)
              do idim=1,nd
@@ -1353,6 +1369,7 @@ c      temp variables
           iz = 1.05d0*(centers(3,jbox)-ctmp(3))/bs
 
          
+          jbox = jbox - mexpoffset
           do j=1,nexptotp
              zmul = zs(-iy,j)*xs(-iz,j)*ys(-ix,j)
              do idim=1,nd
@@ -1368,6 +1385,7 @@ c      temp variables
           iy = 1.05d0*(centers(2,jbox)-ctmp(2))/bs
           iz = 1.05d0*(centers(3,jbox)-ctmp(3))/bs
          
+          jbox = jbox - mexpoffset
           do j=1,nexptotp
              zmul = zs(-iy,j)*xs(-iz,j)*ys(-ix,j)
              do idim=1,nd
@@ -1383,6 +1401,7 @@ c      temp variables
           iy = 1.05d0*(centers(2,jbox)-ctmp(2))/bs
           iz = 1.05d0*(centers(3,jbox)-ctmp(3))/bs
          
+          jbox = jbox - mexpoffset
           do j=1,nexptotp
              zmul = zs(-iy,j)*xs(-iz,j)*ys(-ix,j)
              do idim=1,nd
@@ -1398,6 +1417,7 @@ c      temp variables
           iy = 1.05d0*(centers(2,jbox)-ctmp(2))/bs
           iz = 1.05d0*(centers(3,jbox)-ctmp(3))/bs
          
+          jbox = jbox - mexpoffset
           do j=1,nexptotp
              zmul = zs(-iy,j)*xs(-iz,j)*ys(-ix,j)
              do idim=1,nd
@@ -1726,7 +1746,8 @@ c--------------------------------------------------------------------
      8           mexpe6,mexpe8,mexpwall,mexpw1357,mexpw13,mexpw57,
      9           mexpw1,mexpw3,mexpw5,mexpw7,rdminus,
      9           xs,ys,zs,fexpback,rlsc,
-     9           pgboxwexp,cntlist4,list4,nlist4s,ilist4,mnlist4)
+     9           pgboxwexp,cntlist4,list4,nlist4s,ilist4,mnlist4,
+     9           nboxesilev,mexpoffset)
 c--------------------------------------------------------------------
 c      process east west expansions for box ibox
 c-------------------------------------------------------------------
@@ -1747,7 +1768,10 @@ c-------------------------------------------------------------------
        complex *16 rlams(*),whts(*)
        complex *16 tloc(nd,0:nterms,-nterms:nterms)
        complex *16, allocatable :: tloc2(:,:,:)
-       complex *16 mexp(nd,nexptotp,nboxes,6)
+       integer *8 nboxesilev
+       integer *8 mexpoffset
+       complex *16 mexp(nd,nexptotp,nboxesilev,6)
+c       complex *16 mexp(nd,nexptotp,nboxes,6)
        real *8 rdminus(0:nterms,0:nterms,-nterms:nterms)
        real *8 rmlexp(*),centers(3,*)
        complex *16 mexpup(nd,nexptot),mexpdown(nd,nexptot)
@@ -1809,6 +1833,7 @@ c      temp variables
           iy = 1.05d0*(centers(2,jbox)-ctmp(2))/bs
           iz = 1.05d0*(centers(3,jbox)-ctmp(3))/bs
          
+          jbox = jbox - mexpoffset
           do j=1,nexptotp
              zmul = zs(ix,j)*xs(-iz,j)*ys(iy,j)
              do idim=1,nd
@@ -1824,6 +1849,7 @@ c      temp variables
           iy = 1.05d0*(centers(2,jbox)-ctmp(2))/bs
           iz = 1.05d0*(centers(3,jbox)-ctmp(3))/bs
          
+          jbox = jbox - mexpoffset
           do j=1,nexptotp
              zmul = zs(ix,j)*xs(-iz,j)*ys(iy,j)
              do idim=1,nd
@@ -1839,6 +1865,7 @@ c      temp variables
           iy = 1.05d0*(centers(2,jbox)-ctmp(2))/bs
           iz = 1.05d0*(centers(3,jbox)-ctmp(3))/bs
          
+          jbox = jbox - mexpoffset
           do j=1,nexptotp
              zmul = zs(ix,j)*xs(-iz,j)*ys(iy,j)
              do idim=1,nd
@@ -1855,6 +1882,7 @@ c      temp variables
           iy = 1.05d0*(centers(2,jbox)-ctmp(2))/bs
           iz = 1.05d0*(centers(3,jbox)-ctmp(3))/bs
          
+          jbox = jbox - mexpoffset
           do j=1,nexptotp
              zmul = zs(ix,j)*xs(-iz,j)*ys(iy,j)
              do idim=1,nd
@@ -1870,6 +1898,7 @@ c      temp variables
           iy = 1.05d0*(centers(2,jbox)-ctmp(2))/bs
           iz = 1.05d0*(centers(3,jbox)-ctmp(3))/bs
          
+          jbox = jbox - mexpoffset
           do j=1,nexptotp
              zmul = zs(ix,j)*xs(-iz,j)*ys(iy,j)
              do idim=1,nd
@@ -1886,6 +1915,7 @@ c      temp variables
           iy = 1.05d0*(centers(2,jbox)-ctmp(2))/bs
           iz = 1.05d0*(centers(3,jbox)-ctmp(3))/bs
          
+          jbox = jbox - mexpoffset
           do j=1,nexptotp
              zmul = zs(ix,j)*xs(-iz,j)*ys(iy,j)
              do idim=1,nd
@@ -1901,6 +1931,7 @@ c      temp variables
           iy = 1.05d0*(centers(2,jbox)-ctmp(2))/bs
           iz = 1.05d0*(centers(3,jbox)-ctmp(3))/bs
          
+          jbox = jbox - mexpoffset
           do j=1,nexptotp
              zmul = zs(ix,j)*xs(-iz,j)*ys(iy,j)
              do idim=1,nd
@@ -1917,6 +1948,7 @@ c      temp variables
           iy = 1.05d0*(centers(2,jbox)-ctmp(2))/bs
           iz = 1.05d0*(centers(3,jbox)-ctmp(3))/bs
          
+          jbox = jbox - mexpoffset
           do j=1,nexptotp
              zmul = zs(ix,j)*xs(-iz,j)*ys(iy,j)
              do idim=1,nd
@@ -1934,6 +1966,7 @@ c      temp variables
           iz = 1.05d0*(centers(3,jbox)-ctmp(3))/bs
 
          
+          jbox = jbox - mexpoffset
           do j=1,nexptotp
              zmul = zs(-ix,j)*xs(iz,j)*ys(-iy,j)
              do idim=1,nd
@@ -1949,6 +1982,7 @@ c      temp variables
           iy = 1.05d0*(centers(2,jbox)-ctmp(2))/bs
           iz = 1.05d0*(centers(3,jbox)-ctmp(3))/bs
          
+          jbox = jbox - mexpoffset
           do j=1,nexptotp
              zmul = zs(-ix,j)*xs(iz,j)*ys(-iy,j)
              do idim=1,nd
@@ -1964,6 +1998,7 @@ c      temp variables
           iy = 1.05d0*(centers(2,jbox)-ctmp(2))/bs
           iz = 1.05d0*(centers(3,jbox)-ctmp(3))/bs
          
+          jbox = jbox - mexpoffset
           do j=1,nexptotp
              zmul = zs(-ix,j)*xs(iz,j)*ys(-iy,j)
              do idim=1,nd
@@ -1982,6 +2017,7 @@ c      temp variables
           iy = 1.05d0*(centers(2,jbox)-ctmp(2))/bs
           iz = 1.05d0*(centers(3,jbox)-ctmp(3))/bs
          
+          jbox = jbox - mexpoffset
           do j=1,nexptotp
              zmul = zs(-ix,j)*xs(iz,j)*ys(-iy,j)
              do idim=1,nd
@@ -1997,6 +2033,7 @@ c      temp variables
           iy = 1.05d0*(centers(2,jbox)-ctmp(2))/bs
           iz = 1.05d0*(centers(3,jbox)-ctmp(3))/bs
          
+          jbox = jbox - mexpoffset
           do j=1,nexptotp
              zmul = zs(-ix,j)*xs(iz,j)*ys(-iy,j)
              do idim=1,nd
@@ -2013,6 +2050,7 @@ c      temp variables
           iy = 1.05d0*(centers(2,jbox)-ctmp(2))/bs
           iz = 1.05d0*(centers(3,jbox)-ctmp(3))/bs
          
+          jbox = jbox - mexpoffset
           do j=1,nexptotp
              zmul = zs(-ix,j)*xs(iz,j)*ys(-iy,j)
              do idim=1,nd
@@ -2028,6 +2066,7 @@ c      temp variables
           iy = 1.05d0*(centers(2,jbox)-ctmp(2))/bs
           iz = 1.05d0*(centers(3,jbox)-ctmp(3))/bs
          
+          jbox = jbox - mexpoffset
           do j=1,nexptotp
              zmul = zs(-ix,j)*xs(iz,j)*ys(-iy,j)
              do idim=1,nd
@@ -2043,6 +2082,7 @@ c      temp variables
           iy = 1.05d0*(centers(2,jbox)-ctmp(2))/bs
           iz = 1.05d0*(centers(3,jbox)-ctmp(3))/bs
          
+          jbox = jbox - mexpoffset
           do j=1,nexptotp
              zmul = zs(-ix,j)*xs(iz,j)*ys(-iy,j)
              do idim=1,nd
@@ -3800,7 +3840,8 @@ c--------------------------------------------------------------------
      2           nphysical,nthmax,nexptot,nexptotp,mexp,nuall,uall,
      3           ndall,dall,mexpup,mexpdown,
      4           mexpupphys,mexpdownphys,mexpuall,mexpdall,
-     5           xs,ys,zs,fexpback,rlsc)
+     5           xs,ys,zs,fexpback,rlsc,
+     6           nboxesilev,mexpoffset)
 c--------------------------------------------------------------------
 c      process up down expansions for box ibox
 c-------------------------------------------------------------------
@@ -3814,7 +3855,10 @@ c-------------------------------------------------------------------
       double precision rscale
       double complex rlams(*),whts(*)
       double complex, allocatable :: tloc(:,:,:)  
-      double complex mexp(nd,nexptotp,nboxes,6)
+      integer *8 nboxesilev
+      integer *8 mexpoffset
+      double complex mexp(nd,nexptotp,nboxesilev,6)
+c      double complex mexp(nd,nexptotp,nboxes,6)
       double complex rmlexp(nd*(nterms+1)*(2*nterms+1),8)
       double precision centers(3,*)
       double complex mexpup(nd,nexptot),mexpdown(nd,nexptot)
@@ -3855,6 +3899,7 @@ C        print *,"ulist j: ",jbox
         iy = 1.05d0*(centers(2,jbox)-ctmp(2))/rscale
         iz = 1.05d0*(centers(3,jbox)-ctmp(3))/rscale
          
+        jbox = jbox - mexpoffset
         do j=1,nexptotp
           zmul = zs(iz,j)*xs(ix,j)*ys(iy,j)
           do idim=1,nd
@@ -3871,6 +3916,7 @@ C        print *,"dlist j: ",jbox
         iy = 1.05d0*(centers(2,jbox)-ctmp(2))/rscale
         iz = 1.05d0*(centers(3,jbox)-ctmp(3))/rscale
 
+        jbox = jbox - mexpoffset
         do j=1,nexptotp
           zmul = zs(-iz,j)*xs(-ix,j)*ys(-iy,j)
           do idim=1,nd
@@ -4115,7 +4161,8 @@ c--------------------------------------------------------------------
      2           nphysical,nthmax,nexptot,nexptotp,mexp,nnall,nall,
      3           nsall,sall,mexpup,mexpdown,
      4           mexpupphys,mexpdownphys,mexpnall,mexpsall,
-     5           rdplus,xs,ys,zs,fexpback,rlsc)
+     5           rdplus,xs,ys,zs,fexpback,rlsc,
+     6           nboxesilev,mexpoffset)
 c--------------------------------------------------------------------
 c      create up down expansions for box ibox
 c-------------------------------------------------------------------
@@ -4130,7 +4177,10 @@ c-------------------------------------------------------------------
       double complex rlams(*),whts(*)
       double complex, allocatable :: tloc(:,:,:)
       double complex, allocatable :: tloc2(:,:,:)
-      double complex mexp(nd,nexptotp,nboxes,6)
+      integer *8 nboxesilev
+      integer *8 mexpoffset
+      double complex mexp(nd,nexptotp,nboxesilev,6)
+c      double complex mexp(nd,nexptotp,nboxes,6)
       double precision rdplus(0:nterms,0:nterms,-nterms:nterms)
       double complex rmlexp(nd*(nterms+1)*(2*nterms+1),8)
       double precision centers(3,*)
@@ -4171,6 +4221,7 @@ c      temp variables
         iy = 1.05d0*(centers(2,jbox)-ctmp(2))/rscale
         iz = 1.05d0*(centers(3,jbox)-ctmp(3))/rscale
          
+        jbox = jbox - mexpoffset
         do j=1,nexptotp
            zmul = zs(iy,j)*xs(iz,j)*ys(ix,j)
            do idim=1,nd
@@ -4188,6 +4239,7 @@ c      temp variables
         iy = 1.05d0*(centers(2,jbox)-ctmp(2))/rscale
         iz = 1.05d0*(centers(3,jbox)-ctmp(3))/rscale
          
+        jbox = jbox - mexpoffset
         do j=1,nexptotp
           zmul = zs(-iy,j)*xs(-iz,j)*ys(-ix,j)
           do idim=1,nd
@@ -4437,7 +4489,8 @@ c--------------------------------------------------------------------
      2           nphysical,nthmax,nexptot,nexptotp,mexp,neall,eall,
      3           nwall,wall,mexpup,mexpdown,
      4           mexpupphys,mexpdownphys,mexpeall,mexpwall,
-     5           rdminus,xs,ys,zs,fexpback,rlsc)
+     5           rdminus,xs,ys,zs,fexpback,rlsc,
+     6           nboxesilev,mexpoffset)
 c--------------------------------------------------------------------
 c      create up down expansions for box ibox
 c-------------------------------------------------------------------
@@ -4451,7 +4504,10 @@ c-------------------------------------------------------------------
       double precision rscale
       double complex rlams(*),whts(*)
       double complex, allocatable :: tloc(:,:,:),tloc2(:,:,:)
-      double complex mexp(nd,nexptotp,nboxes,6)
+      integer *8 nboxesilev
+      integer *8 mexpoffset
+      double complex mexp(nd,nexptotp,nboxesilev,6)
+c      double complex mexp(nd,nexptotp,nboxes,6)
       double precision rdminus(0:nterms,0:nterms,-nterms:nterms)
       double complex rmlexp(nd*(nterms+1)*(2*nterms+1),8)
       double precision centers(3,*)
@@ -4492,6 +4548,7 @@ c      temp variables
         iy = 1.05d0*(centers(2,jbox)-ctmp(2))/rscale
         iz = 1.05d0*(centers(3,jbox)-ctmp(3))/rscale
          
+        jbox = jbox - mexpoffset
         do j=1,nexptotp
           zmul = zs(ix,j)*xs(-iz,j)*ys(iy,j)
           do idim=1,nd
@@ -4509,6 +4566,7 @@ c      temp variables
         iz = 1.05d0*(centers(3,jbox)-ctmp(3))/rscale
 
          
+        jbox = jbox - mexpoffset
         do j=1,nexptotp
           zmul = zs(-ix,j)*xs(iz,j)*ys(-iy,j)
           do idim=1,nd


### PR DESCRIPTION
This PR reduces the Helmholtz memory usage by:
1. Fix the ndiv for Helmholtz, considering the box size and zk;
2. Reduce the mexp memory footprint using the per-level number of boxes.

Co-authored with @mrachh